### PR TITLE
PR for Feature/friendship v2

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -397,3 +397,7 @@ li {
     margin-right: 15px;
   }
 }
+
+.mutual-header {
+  margin-top: 15px;
+}

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -22,7 +22,6 @@ class FriendshipsController < ApplicationController
     @friend_request = Friendship.find_by(user_id: params[:id], friend_id: current_user.id)
     if @friend_request.update(state: Friendship::CONFIRMED)
       flash[:notice] = 'Friend Request Confirmed'
-      # friend = User.find(@friend_request.user_id)
       Friendship.create!(user_id: @friend_request.friend_id, friend_id: @friend_request.user_id, state: Friendship::CONFIRMED)
       redirect_to users_path
     end
@@ -32,7 +31,11 @@ class FriendshipsController < ApplicationController
   end
 
   def destroy
-    redirect_to users_path if @friendship.destroy
+    if @friendship.destroy
+      Friendship.find_by(user_id: current_user.id, friend_id: params[:id]).destroy
+      flash[:notice] = 'Friend removed!'
+      redirect_to users_path
+    end
   rescue StandardError
     flash[:alert] = 'Something Went Wrong!'
     redirect_to users_path

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -20,8 +20,12 @@ class FriendshipsController < ApplicationController
 
   def update
     @friend_request = Friendship.find_by(user_id: params[:id], friend_id: current_user.id)
-    @friend_request.update(state: Friendship::CONFIRMED)
-    redirect_to users_path
+    if @friend_request.update(state: Friendship::CONFIRMED)
+      flash[:notice] = 'Friend Request Confirmed'
+      # friend = User.find(@friend_request.user_id)
+      Friendship.create!(user_id: @friend_request.friend_id, friend_id: @friend_request.user_id, state: Friendship::CONFIRMED)
+      redirect_to users_path
+    end
   rescue StandardError
     flash[:alert] = 'Something Went Wrong!'
     redirect_to users_path

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -12,33 +12,25 @@ class FriendshipsController < ApplicationController
         flash[:alert] = 'Something Went Wrong!'
       end
     else
-      flash[:notice] = 'Sorry! there is already a friend request pending with this user!'
+      flash[:notice] = 'Sorry! you already have a pending friend request with this user!'
     end
-
     redirect_to users_path
   end
 
   def update
     @friend_request = Friendship.find_by(user_id: params[:id], friend_id: current_user.id)
-    if @friend_request.update(state: Friendship::CONFIRMED)
-      flash[:notice] = 'Friend Request Confirmed'
-      Friendship.create!(user_id: @friend_request.friend_id, friend_id: @friend_request.user_id,
-                         state: Friendship::CONFIRMED)
-      redirect_to users_path
-    end
+    @friend_request.confirm_friend
+    redirect_to users_path
   rescue StandardError
     flash[:alert] = 'Something Went Wrong!'
     redirect_to users_path
   end
 
   def destroy
-    if @friendship.destroy
-      Friendship.find_by(user_id: current_user.id, friend_id: params[:id]).destroy
-      flash[:notice] = 'Friend removed!'
-      redirect_to users_path
-    end
+    @friendship.unfriend
+    flash[:notice] = 'Friend removed!'
+    redirect_to users_path
   rescue StandardError
-    flash[:alert] = 'Something Went Wrong!'
     redirect_to users_path
   end
 

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -22,7 +22,8 @@ class FriendshipsController < ApplicationController
     @friend_request = Friendship.find_by(user_id: params[:id], friend_id: current_user.id)
     if @friend_request.update(state: Friendship::CONFIRMED)
       flash[:notice] = 'Friend Request Confirmed'
-      Friendship.create!(user_id: @friend_request.friend_id, friend_id: @friend_request.user_id, state: Friendship::CONFIRMED)
+      Friendship.create!(user_id: @friend_request.friend_id, friend_id: @friend_request.user_id,
+                         state: Friendship::CONFIRMED)
       redirect_to users_path
     end
   rescue StandardError

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -20,8 +20,7 @@ class PostsController < ApplicationController
   private
 
   def timeline_posts
-    posts = Post.where('user_id IN (?)', current_user.all_friends_ids)
-    @timeline_posts ||= posts.ordered_by_most_recent
+    @timeline_posts ||= current_user.friends_and_own_posts.ordered_by_most_recent
   end
 
   def post_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -56,8 +56,6 @@ module ApplicationHelper
   end
 
   def list_mutual_friends(user)
-    if user != current_user
-      render user.mutual_friends(user).reject { |friend| friend == current_user }
-    end    
+    render(user.mutual_friends(user).reject { |friend| friend == current_user }) if user != current_user
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -50,4 +50,14 @@ module ApplicationHelper
       render user.friend_requests
     end
   end
+
+  def mutual_friends_header(user)
+    content_tag :h4, 'Mutual Friends:', class: 'mutual-header' if user != current_user
+  end
+
+  def list_mutual_friends(user)
+    if user != current_user
+      render user.mutual_friends(user).reject { |friend| friend == current_user }
+    end    
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -58,4 +58,13 @@ module ApplicationHelper
   def list_mutual_friends(user)
     render(user.mutual_friends(user).reject { |friend| friend == current_user }) if user != current_user
   end
+
+  def show_menu_links
+    if current_user
+      link_to(current_user.name, user_path(current_user), class: 'menu-item') +
+        link_to('Sign out', destroy_user_session_path, method: :delete)
+    else
+      link_to 'Sign in', user_session_path
+    end
+  end
 end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -6,4 +6,13 @@ class Friendship < ApplicationRecord
     REQUEST = 'request'.freeze,
     CONFIRMED = 'confirmed'.freeze
   ].freeze
+
+  def confirm_friend
+    update_attributes(state: CONFIRMED)
+    Friendship.create!(user_id: friend_id, friend_id: user_id, state: CONFIRMED)
+  end
+
+  def unfriend
+    Friendship.find_by(user_id: friend_id, friend_id: user_id).destroy if destroy
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,11 +27,11 @@ class User < ApplicationRecord
     friends.include?(user)
   end
 
-  def all_friends_ids
-    friends.ids << id
-  end
-
   def mutual_friends(user)
     friends & user.friends
+  end
+
+  def friends_and_own_posts
+    Post.where(user: (friends.to_a << self))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,4 +30,8 @@ class User < ApplicationRecord
   def all_friends_ids
     friends.ids << id
   end
+
+  def mutual_friends(user)
+    friends & user.friends
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,8 +39,6 @@ class User < ApplicationRecord
   end
 
   def all_friends_ids
-    fc = friendships_confirmed.ids
-    cf = confirmed_friendships.ids
-    fc + cf << id
+    friends.ids << id
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,9 +24,7 @@ class User < ApplicationRecord
   has_many :friend_requests, through: :friend_requests_received, source: :user
 
   def friend?(user)
-    friendship = Friendship.find_by(user_id: user.id, friend_id: id, state: Friendship::CONFIRMED) ||
-                 Friendship.find_by(user_id: id, friend_id: user.id, state: Friendship::CONFIRMED)
-    true unless friendship.nil?
+    friends.include?(user)
   end
 
   def all_friends_ids

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,15 +21,6 @@ class User < ApplicationRecord
                                         where(state: Friendship::REQUEST)
                                       }, class_name: 'Friendship', foreign_key: 'friend_id'
 
-  has_many :confirmed_requests, lambda {
-                                  where(state: Friendship::CONFIRMED)
-                                }, class_name: 'Friendship', foreign_key: 'friend_id'
-  has_many :friendships_confirmed, through: :confirmed_requests, source: :user
-  has_many :requests_confirmed, lambda {
-                                  where(state: Friendship::CONFIRMED)
-                                }, class_name: 'Friendship', foreign_key: 'user_id'
-  has_many :confirmed_friendships, through: :requests_confirmed, source: :friend
-
   has_many :friend_requests, through: :friend_requests_received, source: :user
 
   def friend?(user)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,14 +18,7 @@
           <%= menu_link_to 'All users', users_path %>
         </div>
       </div>
-      <% if current_user %>
-         <div class="menu-item">
-            <%= link_to current_user.name, user_path(current_user) %>
-        </div>
-        <%= link_to 'Sign out', destroy_user_session_path, method: :delete %>
-      <% else %>
-        <%= link_to 'Sign in', user_session_path %>
-      <% end %>
+      <%= show_menu_links %>
     </nav>
     <% if notice.present? %>
       <div class="notice">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -4,6 +4,10 @@
   <ul> 
     <%= list_friend_requests(@user) %>
   </ul>
+  <%= mutual_friends_header(@user) %>
+  <ul> 
+    <%= list_mutual_friends(@user) %>
+  </ul>
   <article class="timeline">
     <h3>Recent posts:</h3>
     <ul class="posts">

--- a/spec/models/friendship_spec.rb
+++ b/spec/models/friendship_spec.rb
@@ -15,7 +15,9 @@ RSpec.describe Friendship, type: :model do
   end
 
   it 'can check if user_one is a friend to user_two and vice-versa' do
-    user_one.friendships.create(user_id: user_one.id, friend_id: user_two.id, state: Friendship::CONFIRMED)
+    user_one.friendships.create!(user_id: user_one.id, friend_id: user_two.id, state: Friendship::CONFIRMED)
+    user_two.friendships.create(user_id: user_two.id, friend_id: user_one.id, state: Friendship::CONFIRMED)
     expect(user_two.friend?(user_one)).to eql(true)
+    expect(user_one.friend?(user_two)).to eql(true)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe User, type: :model do
     describe 'friendship status' do
       it 'checks if users are friends' do
         user_one.friendships.create(user_id: user_one.id, friend_id: user_two.id, state: Friendship::CONFIRMED)
-        expect(user_two.friend?(user_one)).to eql(true)
+        expect(user_one.friend?(user_two)).to eql(true)
       end
 
       it 'checks for existance of friend requests' do


### PR DESCRIPTION
This pull request submits the following added features:

* Implement mutual friendship
  - One can see mutual friends on the show user page

* Refactor **`#friend?`**
  - This method now uses the **`has_many friends`** relationship to check whether a user is a friend to another user

* Refactor #destroy
   -  #destroy can now delete two rows of friendships between two users

* Refactor #all_friends_id
   -  #all_friends_ids now uses user.friends association

* Refactor #update to create two rows in Friendships